### PR TITLE
Fragments in one repo

### DIFF
--- a/release/to-release.cfg
+++ b/release/to-release.cfg
@@ -2,10 +2,9 @@ Knotx;knotx-dependencies
 Knotx;knotx-commons
 Knotx;knotx-launcher
 Knotx;knotx-junit5
-Knotx;knotx-fragment-api
 Knotx;knotx-server-http
 Knotx;knotx-repository-connector
-Knotx;knotx-fragments-handler
+Knotx;knotx-fragments
 Knotx;knotx-data-bridge
 Knotx;knotx-template-engine
 Knotx;knotx-stack

--- a/repositories.cfg
+++ b/repositories.cfg
@@ -1,12 +1,13 @@
 Knotx;knotx-dependencies
+Knotx;knotx-gradle-plugins
 Knotx;knotx-commons
 Knotx;knotx-junit5
 Knotx;knotx-launcher
-Knotx;knotx-fragment-api
 Knotx;knotx-server-http
 Knotx;knotx-repository-connector
-Knotx;knotx-fragments-handler
+Knotx;knotx-fragments
 Knotx;knotx-data-bridge
 Knotx;knotx-template-engine
 Knotx;knotx-stack
 Knotx;knotx-docker
+Knotx;knotx-starter-kit


### PR DESCRIPTION
Adjust to moving all fragments-related core repos into `knotx-fragments` repository.