### PR TITLE
Add starter-kit module to release procedure

### DIFF
--- a/release/close-release.sh
+++ b/release/close-release.sh
@@ -9,6 +9,7 @@ CURRENT_DIR="$(dirname "${0}")/"
 # ToDo - better way to manage scripts includes
 . "$CURRENT_DIR"helpers/git-release.sh
 . "$CURRENT_DIR"helpers/github-release.sh
+. "$CURRENT_DIR"helpers/gradle-github-tag.sh
 . "$CURRENT_DIR"helpers/maven-release.sh
 . "$CURRENT_DIR"helpers/gradle-release.sh
 . "$CURRENT_DIR"helpers/bintray-upload.sh
@@ -33,9 +34,15 @@ do
     echo "$opeartion"
     maven_close_release $project ${DEV_VERSION}; fail_fast_operation $? "$operation"
   else
-    operation="Closing release of Gradle repo $project"
-    echo "$opeartion"
-    gradle_close_release $project ${DEV_VERSION}; fail_fast_operation $? "$operation"
+    if grep -q "releasable=false" "knotx-repos/${project}/gradle.properties"; then
+      operation="Pusing repo $project"
+      echo "$operation"
+      gradle_github_close_tag $project ${DEV_VERSION}; fail_fast_operation $? "$operation"
+    else
+      operation="Closing release of Gradle repo $project"
+      echo "$opeartion"
+      gradle_close_release $project ${DEV_VERSION}; fail_fast_operation $? "$operation"
+    fi
   fi
 
   echo "______________________________________________________________________"

--- a/release/helpers/github-release.sh
+++ b/release/helpers/github-release.sh
@@ -6,5 +6,5 @@ update_changelog() {
 
   gsed -i '/List of changes that are finished but not yet released in any final version./a \
 \
-## Version '"${version}"'' knotx-repos/${project}/CHANGELOG.md
+## '"${version}"'' knotx-repos/${project}/CHANGELOG.md
 }

--- a/release/helpers/github-release.sh
+++ b/release/helpers/github-release.sh
@@ -4,7 +4,7 @@ update_changelog() {
   local project="$1"
   local version="$2"
 
-  sed -i '/List of changes that are finished but not yet released in any final version./a \
+  gsed -i '/List of changes that are finished but not yet released in any final version./a \
 \
 ## Version '"${version}"'' knotx-repos/${project}/CHANGELOG.md
 }

--- a/release/helpers/gradle-github-tag.sh
+++ b/release/helpers/gradle-github-tag.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+gradle_github_tag() {
+  echo "************************************************************"
+  local project="$1"
+  local version="$2"
+
+  echo "Creating tag of ${project} ${version}"
+  # TODO fix to change only when line starts with 'version'
+  # gsed -i "/version/c version=${version}" knotx-repos/${project}/gradle.properties
+  gsed -i "/knotx.version/c knotx.version=${version}" knotx-repos/${project}/gradle.properties
+
+  git_commit_and_create_tag $project $version
+  echo "************************************************************"
+}
+
+gradle_github_close_tag() {
+  echo "************************************************************"
+  project="$1"
+  dev_version="$2"
+
+  echo "Set next development version to ${dev_version}"
+  git_set_next_dev_version $project $dev_version
+
+  git_push_changes $project
+  echo "************************************************************"
+}

--- a/release/helpers/gradle-github-tag.sh
+++ b/release/helpers/gradle-github-tag.sh
@@ -9,6 +9,7 @@ gradle_github_tag() {
   # TODO fix to change only when line starts with 'version'
   # gsed -i "/version/c version=${version}" knotx-repos/${project}/gradle.properties
   gsed -i "/knotx.version/c knotx.version=${version}" knotx-repos/${project}/gradle.properties
+  update_changelog $project $version
 
   git_commit_and_create_tag $project $version
   echo "************************************************************"

--- a/release/helpers/gradle-release.sh
+++ b/release/helpers/gradle-release.sh
@@ -8,10 +8,9 @@ gradle_start_release() {
 
   # Set release version
   gradle_set_project_version $project $version
-#  update_changelog $project $version
+  update_changelog $project $version
 
   # Release
-  # knotx-repos/${project}/gradlew -p knotx-repos/${project} publishToMavenLocal
   knotx-repos/${project}/gradlew -p knotx-repos/${project} publishToMavenLocal publish -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
   git_commit_and_create_tag $project $version

--- a/release/helpers/maven-release.sh
+++ b/release/helpers/maven-release.sh
@@ -7,7 +7,7 @@ maven_start_release() {
   echo "Starting release of ${project} ${version}"
 
   mvn -f knotx-repos/${project}/pom.xml versions:set -DnewVersion=${version} -DgenerateBackupPoms=false
-#  update_changelog $project $version
+  update_changelog $project $version
 
   mvn -f knotx-repos/${project}/pom.xml clean deploy -Prelease
   git_commit_and_create_tag $project $version
@@ -18,9 +18,6 @@ maven_close_release() {
   echo "************************************************************"
   local project="$1"
   local dev_version="$2"
-
-#  echo "Releasing ${project} to central"
-#  mvn -f knotx-repos/${project}/pom.xml nexus-staging:release
 
   echo "Set next development version to ${dev_version}"
   mvn -f knotx-repos/${project}/pom.xml versions:set -DnewVersion=${dev_version} -DgenerateBackupPoms=false

--- a/release/start-release.sh
+++ b/release/start-release.sh
@@ -6,6 +6,7 @@ CURRENT_DIR="$(dirname "${0}")/"
 # ToDo - better way to manage scripts includes
 . "$CURRENT_DIR"helpers/git-release.sh
 . "$CURRENT_DIR"helpers/github-release.sh
+. "$CURRENT_DIR"helpers/gradle-github-tag.sh
 . "$CURRENT_DIR"helpers/maven-release.sh
 . "$CURRENT_DIR"helpers/gradle-release.sh
 . "$CURRENT_DIR"helpers/misc.sh
@@ -33,12 +34,18 @@ do
 
   if [[ -f "knotx-repos/$project/pom.xml" ]]; then
     operation="Releasing Maven repo $project"
-    echo "$opeartion"
+    echo "$operation"
     maven_start_release $project ${VERSION}; fail_fast_operation $? "$operation"
   else
-    operation="Releasing Gradle repo $project"
-    echo "$opeartion"
-    gradle_start_release $project ${VERSION}; fail_fast_operation $? "$operation"
+    if grep -q "releasable=false" "knotx-repos/${project}/gradle.properties"; then
+      operation="Tagging repo $project"
+      echo "$operation"
+      gradle_github_tag $project ${VERSION}; fail_fast_operation $? "$operation"
+    else
+      operation="Releasing Gradle repo $project"
+      echo "$operation"
+      gradle_start_release $project ${VERSION}; fail_fast_operation $? "$operation"
+    fi
   fi
 
   echo "______________________________________________________________________"

--- a/release/to-release.cfg
+++ b/release/to-release.cfg
@@ -9,3 +9,4 @@ Knotx;knotx-data-bridge
 Knotx;knotx-template-engine
 Knotx;knotx-stack
 Knotx;knotx-docker
+Knotx;knotx-starter-kit


### PR DESCRIPTION
This PR:
- adds [Knot.x Starter Kit](https://github.com/Knotx/knotx-starter-kit) to release procedure - we tag the repository and update the changelog with released version
- fixes commented changelog update script