### PR TITLE
[#13] pull-all not working as expected on Windows and Linux, missing help information

### DIFF
--- a/development/build-stack.sh
+++ b/development/build-stack.sh
@@ -1,16 +1,5 @@
 #!/usr/bin/env bash
 
-while getopts hr:di option
-do
-  case "${option}"
-    in
-    h) help;;
-    r) ROOT=${OPTARG};;
-    d) DEPLOY=true;;
-    i) DOCKER_IMAGE=true;;
-  esac
-done
-
 #########################
 # The command line help #
 #########################
@@ -80,6 +69,20 @@ build_docker_with_maven () {
   mvn -f $1/pom.xml clean package; fail_fast_build $? $1
 }
 
+#########################
+#         Main          #
+#########################
+
+while getopts hr:di option
+do
+  case "${option}"
+    in
+    h) help;;
+    r) ROOT=${OPTARG};;
+    d) DEPLOY=true;;
+    i) DOCKER_IMAGE=true;;
+  esac
+done
 
 #########################
 #       Execute         #

--- a/development/pull-all.sh
+++ b/development/pull-all.sh
@@ -4,34 +4,6 @@
 # eval `ssh-agent`
 # ssh-add ~/.ssh/id_rsa
 
-while getopts hr:b:fcm:a option
-do
-  case "${option}"
-    in
-    h) help;;
-    r) ROOT=${OPTARG};;
-    b) BRANCH=${OPTARG};;
-    f) FORCE=true;;
-    c) CREATE=true;;
-    m) MERGE=${OPTARG};;
-    a) HTTPS=true;;
-  esac
-done
-
-echo "Script root catalogue [$ROOT]"
-echo "GIT branch name [$BRANCH]"
-
-if [[ $FORCE ]]; then
-  while true; do
-    read -p "Do you wish to RESET all changes in all repositories to HEAD and switch to [$BRANCH] [yes/no]? " yn
-    case $yn in
-        [Yy]* ) break;;
-        [Nn]* ) echo "Script NOT executed!"; exit;;
-        * ) echo "Please answer yes or no.";;
-    esac
-  done
-fi
-
 #########################
 # The command line help #
 #########################
@@ -43,6 +15,7 @@ help() {
     echo "   -c                         create GIT branch if not exists"
     echo "   -f                         reset all changes if repository is cloned"
     echo "   -m                         merge / rebase with branch '-m original/master'"
+    echo "   -a                         clone with HTTPS instead of clone with SSH (defult)"
     echo
     echo "Examples:"
     echo "   sh pull-all.sh -r projects/knotx -b master                                   clones (if not exists) all repositories to 'projects/knotx' folder and switches to master branch"
@@ -96,6 +69,38 @@ checkout() {
   fi
   git --git-dir=$2/.git --work-tree=$2 pull
 }
+
+#########################
+#          Main         #
+#########################
+
+while getopts hr:b:fcm:a option
+do
+  case "${option}"
+    in
+    h) help;;
+    r) ROOT=${OPTARG};;
+    b) BRANCH=${OPTARG};;
+    f) FORCE=true;;
+    c) CREATE=true;;
+    m) MERGE=${OPTARG};;
+    a) HTTPS=true;;
+  esac
+done
+
+echo "Script root catalogue [$ROOT]"
+echo "GIT branch name [$BRANCH]"
+
+if [[ $FORCE ]]; then
+  while true; do
+    read -p "Do you wish to RESET all changes in all repositories to HEAD and switch to [$BRANCH] [yes/no]? " yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) echo "Script NOT executed!"; exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+  done
+fi
 
 #########################
 #       Execute         #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
pull-all not working as expected on Windows and Linux, missing help information

## Description
<!--- Describe your changes in detail -->
This is a fix for two issues described in #13. Below is more details about the problems:

1.
In: 
```
development/build-stack.sh
development/pull-all.sh
```
there was a problem to get help for scripts, no matter for which operating system

2.Option -a (to change from SSH clone to HTTPS) was not listed in help method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
