### PR TITLE
Get org from github api

### DIFF
--- a/azure/azure-pipelines.yml
+++ b/azure/azure-pipelines.yml
@@ -29,7 +29,10 @@ steps:
   - task: CmdLine@2
     inputs:
       script: |
-        ORGANIZATION=$(cut -d'/' -f1 <<<$(Build.Repository.Name))
+        PR_NO=$(System.PullRequest.PullRequestNumber)
+        REPO_NAME=$(Build.Repository.Name)
+        LABEL=$(curl https://api.github.com/repos/$REPO_NAME/pulls/$PR_NO | jq --raw-output '.head.label')
+        ORGANIZATION=$(cut -d':' -f1 <<<$LABEL)
         cd knotx-aggregator/development
         if [[ -z "$(System.PullRequest.SourceBranch)" ]] ; then
           ./pull-all.sh -r ../../$(workspaceDir) -b "$(Build.SourceBranchName)" -a -o $ORGANIZATION


### PR DESCRIPTION
Fetches github organisation directly form the GitHub REST API (couldn't obtain one from the Azure variables).
From the GitHub API docs:
> For unauthenticated requests, the rate limit allows for up to 60 requests per hour.

It should be enough for the development purposes. If problems starts occur we can use authenticated endpoint (maybe even GraphQL one) then that allows up to 5k req/h.