### PR TITLE
Update release notes and fix build-stack script

### DIFF
--- a/development/build-stack.sh
+++ b/development/build-stack.sh
@@ -67,8 +67,6 @@ done
 cd ${ROOT}
 touch ${ROOT}/knotx-stack/.composite-enabled
 
-build knotx-gradle-plugins
-knotx-gradle-plugins/gradlew -p knotx-gradle-plugins publishToMavenLocal; fail_fast_build $? true
 build knotx-stack
 publish knotx-stack $DEPLOY
 

--- a/release-gradle/buildSrc/src/main/kotlin/io/knotx/AggregateChangelogsTask.kt
+++ b/release-gradle/buildSrc/src/main/kotlin/io/knotx/AggregateChangelogsTask.kt
@@ -22,7 +22,7 @@ open class AggregateChangelogsTask : DefaultTask() {
     fun execute() {
         val properties = mapOf<String, Any?>(
                 "version" to version,
-                "shortVersion" to version.substringBeforeLast("."),
+                "releaseType" to version.substringAfterLast(".") == "0" ? "minor" : "patch",
                 "releaseDate" to LocalDateTime.now(),
                 "repositories" to buildRepositoriesChangelogs()
         )

--- a/release-gradle/buildSrc/src/main/resources/templates/download.html
+++ b/release-gradle/buildSrc/src/main/resources/templates/download.html
@@ -29,7 +29,7 @@ layout: content-layout
            href="https://repo1.maven.org/maven2/io/knotx/knotx-stack/{{version}}/knotx-stack-{{version}}.zip"
            role="button">
           <span class="fa fa-download"></span>
-          Knot.x {{shortVersion}} (.zip)
+          Knot.x {{version}} (.zip)
           <br>
           <small>{{ releaseDate | date("MMMM dd, yyyy") }} | 20.8 MB</small>
         </a>
@@ -53,7 +53,7 @@ layout: content-layout
            href="https://github.com/Knotx/knotx-starter-kit/archive/{{version}}.zip"
            role="button">
           <span class="fa fa-download"></span>
-          Knot.x Starter Kit {{shortVersion}} (.zip)
+          Knot.x Starter Kit {{version}} (.zip)
           <br>
           <small>{{ releaseDate | date("MMMM dd, yyyy") }} | 87 KB</small>
 

--- a/release-gradle/buildSrc/src/main/resources/templates/index.html.eco
+++ b/release-gradle/buildSrc/src/main/resources/templates/index.html.eco
@@ -15,7 +15,7 @@ layout: default
           <p>
             <a class="btn btn-default btn-lg" href="<%= @getSectionLink('download') %>" role="button">
               <span class="fa fa-download"></span>
-              Knot.x {{shortVersion}}
+              Knot.x {{version}}
             </a>
           </p>
         </span>

--- a/release-gradle/buildSrc/src/main/resources/templates/releaseNotes.html.md
+++ b/release-gradle/buildSrc/src/main/resources/templates/releaseNotes.html.md
@@ -1,15 +1,15 @@
 ---
-title: Knot.x {{shortVersion}} released!
-description: We have just released a minor release Knot.x {{version}}.
-author: admin
+title: Knot.x {{version}} released!
+description: We have just released a {{releaseType}} release Knot.x {{version}}.
 keywords: release
 order: 1
 date: {{ releaseDate | date("yyyy-MM-dd") }}
 knotxVersions:
-  - {{shortVersion}}
+  - {{version}}
 ---
 
-# Knot.x {{shortVersion}}
+# Knot.x {{version}}
+We are extremely pleased to announce that the Knot.x version {{version}} has been released.
 
 
 ## Release Notes


### PR DESCRIPTION
- `build-stack` - no need to build plugins before stack
- updated release-notes for releasing