### PR TITLE
#39 Use proper relative path to touch .composite-enabled file

### DIFF
--- a/development/build-stack.sh
+++ b/development/build-stack.sh
@@ -65,7 +65,7 @@ done
 #       Execute         #
 #########################
 cd ${ROOT}
-touch ${ROOT}/knotx-stack/.composite-enabled
+touch knotx-stack/.composite-enabled
 
 build knotx-stack
 publish knotx-stack $DEPLOY


### PR DESCRIPTION
Fixes relative path handling in `build-stack.sh` script.

## Description
There was an error-prone code for handling path passed to `build-stack -r ROOT` command.
After changing directory to `ROOT`, the `touch` command had an invalid path specified (unless `ROOT` was an absolute path).
This PR fixes the issue by using relative addressing for touching `.composite-enabled` file.

## Motivation and Context
Closes #39

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.